### PR TITLE
Normalize the formatting of mentor details

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-mentor.md
+++ b/.github/ISSUE_TEMPLATE/new-mentor.md
@@ -11,6 +11,6 @@ assignees: ''
 * **Github Username or equivalent handle**: 
 * **Pronouns**: This section is optional, if you'd prefer to leave this blank or remove it that's fine, but it's helpful to trans people if everyone has their pronouns so they don't feel singled out.
 * **Contact**: your preferred method of contact
-* **Spoken Languages**: Languages you're comfortable mentoring in, if you do not specify this English will be assumed.
+* **Spoken Languages**: Languages you're comfortable mentoring in; if you do not specify this English will be assumed. Please _emphasise_ your preferred language if you list more than one.
 * **Topics**: topics of interest or projects that you work on that you're comfortable mentoring.
 * **Additional resources**: Any other learning resources that you maintain that you would like to share

--- a/README.md
+++ b/README.md
@@ -16,35 +16,35 @@ To apply simply open an issue. There is a template setup to help you get started
 
 ## Mentors
 
-### Jane Lusby - [@yaahc](https://github.com/yaahc)
+### Jane Lusby ([@yaahc](https://github.com/yaahc))
 * **Pronouns**: she/her
-* **Contact**: Twitter - [@yaahc_](https://twitter.com/yaahc_)
+* **Contact**: Twitter ([@yaahc_](https://twitter.com/yaahc_))
 * **Spoken Languages**: English
-* **Topics**: beginners, community outreach, cargo, clippy, tracing, CLI
+* **Topics**: Beginners, community outreach, cargo, clippy, tracing, CLI
 
-### Lucio Franco - [@LucioFranco](https://github.com/LucioFranco)
-* **Pronouns**: He/Him
-* **Contact**: Twitter - [@lucio_d_franco](https://twitter.com/lucio_d_franco)
+### Lucio Franco ([@LucioFranco](https://github.com/LucioFranco))
+* **Pronouns**: he/him
+* **Contact**: Twitter ([@lucio_d_franco](https://twitter.com/lucio_d_franco))
 * **Spoken Languages**: English, Italian, French
-* **Topics**: async io, networking, distributed systems, game dev, compilers
+* **Topics**: Async io, networking, distributed systems, game dev, compilers
 
-### Mara Bos - [@m-ou-se](https://github.com/m-ou-se)
+### Mara Bos ([@m-ou-se](https://github.com/m-ou-se))
 * **Pronouns**: she/her
-* **Contact**: E-mail: rust@m-ou.se, or Twitter: [@m_ou_se](https://twitter.com/m_ou_se), or IRC: M-ou-se on Freenode
+* **Contact**: Email ([rust@m-ou.se](mailto:rust@m-ou.se)), Twitter ([@m_ou_se](https://twitter.com/m_ou_se)), or IRC (M-ou-se on Freenode)
 * **Spoken Languages**: English, Dutch
 * **Topics**: Embedded, CLI, math, proc-macro, Linux, undefined behaviour, FFI, lifetimes
 
-### Shady Khalifa - [@shekohex](https://github.com/shekohex)
-* **Pronouns**: He/Him
-* **Contact**: Twitter - [@shekohex](https://twitter.com/ShekoHex)
-* **Spoken Languages**: **Arabic**, English
-* **Topics**: Networking, FFI, CLI, Parsers, Development Tools, Web (Server-Side)
-
-### Søren Mortensen - [@sorenmortensen](https://github.com/sorenmortensen)
+### Shady Khalifa ([@shekohex](https://github.com/shekohex))
 * **Pronouns**: he/him
-* **Contact**: Twitter - [@nerosnm](https://twitter.com/nerosnm) or email - [soren@neros.dev](mailto:soren@neros.dev)
+* **Contact**: Twitter ([@shekohex](https://twitter.com/ShekoHex))
+* **Spoken Languages**: _Arabic_, English
+* **Topics**: Networking, FFI, CLI, parsers, development tools, web (server-side)
+
+### Søren Mortensen ([@sorenmortensen](https://github.com/sorenmortensen))
+* **Pronouns**: he/him
+* **Contact**: Twitter ([@nerosnm](https://twitter.com/nerosnm)) or email ([soren@neros.dev](mailto:soren@neros.dev))
 * **Spoken Languages**: English
-* **Topics**: beginners/the basics, developer tools, CLI, Rust–Swift/Objective-C interop
+* **Topics**: Beginners/the basics, developer tools, CLI, Rust–Swift/Objective-C interop
 
 ## Additional Resources
 * rust-learning - https://github.com/ctjhoa/rust-learning

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ To apply simply open an issue. There is a template setup to help you get started
 ### Lucio Franco ([@LucioFranco](https://github.com/LucioFranco))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@lucio_d_franco](https://twitter.com/lucio_d_franco))
-* **Spoken Languages**: English, Italian, French
+* **Spoken Languages**: _English_, Italian, French
 * **Topics**: Async io, networking, distributed systems, game dev, compilers
 
 ### Mara Bos ([@m-ou-se](https://github.com/m-ou-se))
 * **Pronouns**: she/her
 * **Contact**: Email ([rust@m-ou.se](mailto:rust@m-ou.se)), Twitter ([@m_ou_se](https://twitter.com/m_ou_se)), or IRC (M-ou-se on Freenode)
-* **Spoken Languages**: English, Dutch
+* **Spoken Languages**: English, _Dutch_
 * **Topics**: Embedded, CLI, math, proc-macro, Linux, undefined behaviour, FFI, lifetimes
 
 ### Shady Khalifa ([@shekohex](https://github.com/shekohex))


### PR DESCRIPTION
Including capitalisation, punctuation, list separators, and consistent link formatting.

Signed-off-by: Søren Mortensen <soren@neros.dev>