### PR TITLE
Use Mandarin instead of Chinese

### DIFF
--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -1,6 +1,6 @@
 ### Ana Hobden ([@hoverbear](https://github.com/hoverbear))
 * **Contact:** Email ([ana@hoverbear.org](mailto:ana@hoverbear.org), Twitter ([@a_hoverbear](https://twitter.com/a_hoverbear))
-* **Spoken Language:** _English_, some German, some Chinese
+* **Spoken Language:** _English_, some German, some Mandarin
 * **Topics:** Distributed systems, software evolution, infrastructure, architecture, chaos testing, workshops, proc-macros
 
 ### Andre Bogus ([@llogiq](https://github.com/llogiq))
@@ -98,7 +98,7 @@
 ### Mike Tang ([@daogangtang](https://github.com/daogangtang))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@daogangtang](https://twitter.com/daogangtang))
-* **Spoken Languages**: Chinese, English
+* **Spoken Languages**: Mandarin, English
 * **Topics**: Beginners, community meetup, wasm, web framework, orm, substrate...
 * **Additional Resources**:
   - [rust.cc](https://rust.cc)


### PR DESCRIPTION
Chinese is a **written language** so it should not be included in a **spoken language** section.

Assuming all of them who wrote Chinese here spoke Mandarin *only* since Mandarin is the most widely used language.

Need to ping them here just in case they do not only speak Mandarin or only Mandarin.

@Hoverbear @daogangtang Please reply below to discuss whether you all agree to this change or if amendments are needed.