### PR TITLE
Add dotenv-linter to projects

### DIFF
--- a/_includes/projects.md
+++ b/_includes/projects.md
@@ -7,7 +7,7 @@
 
 ### [Dotenv-linter](https://dotenv-linter.github.io) - ⚡️ Lightning-fast linter for `.env` files. Written in Rust 🦀
 * **Repo**: https://github.com/dotenv-linter/dotenv-linter
-* **Contact**: https://github.com/mgrachev
+* **Contact**: https://twitter.com/mgrachev
 * **Spoken Languages**: English
 * **Recommended Experience**: Beginner
 * **Topics**: CLI, Linters, Dotenv

--- a/_includes/projects.md
+++ b/_includes/projects.md
@@ -5,6 +5,13 @@
 * **Recommended Experience**: Beginner - Intermediate
 * **Topics**: 2D Computer Graphics, Game Engine, Interprocess-Communication, Async, WebAssembly
 
+### [Dotenv-linter](https://dotenv-linter.github.io) - ⚡️ Lightning-fast linter for `.env` files. Written in Rust 🦀
+* **Repo**: https://github.com/dotenv-linter/dotenv-linter
+* **Contact**: https://github.com/mgrachev
+* **Spoken Languages**: English
+* **Recommended Experience**: Beginner
+* **Topics**: CLI, Linters, Dotenv
+
 <h1 id="projects-end"></h1>
 
 <script>


### PR DESCRIPTION
Hi there!

I'd like to add [dotenv-linter](https://github.com/dotenv-linter/dotenv-linter) to projects.

About the project:
It is a friendly Open Source project, the purpose of which is to help other programmers to learn Rust using an example of a simple but at the same time useful tool. In addition to studying Rust, this project has another goal - to instill a love of Open Source and provide an opportunity to contribute to the Open Source project in Rust.