### PR TITLE
Sort projects and mentors by name

### DIFF
--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -317,10 +317,17 @@ do {
     } while (!/^H[123]$/i.test(e.nodeName));
     people.push(person);
 } while (e.nodeName == 'H3');
-for (let i = people.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [people[i], people[j]] = [people[j], people[i]];
-}
+
+// sort mentors by their first name
+people.sort(function(a,b) {
+  return a[0].innerText.localeCompare(b[0].innerText);
+});
+
+//for (let i = people.length - 1; i > 0; i--) {
+//    const j = Math.floor(Math.random() * (i + 1));
+//    [people[i], people[j]] = [people[j], people[i]];
+//}
+
 people.forEach(person => {
     person.forEach(x => {
         e.parentNode.insertBefore(x, e);

--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -148,7 +148,7 @@
 
 ### Kevin Knapp ([@kbknapp](https://github.com/kbknapp))
 * **Pronouns**: he/him
-* **Contact** Twitter ([@thekbknapp](https://twitter.com/thekbknapp)), reddit ([/u/Kbknapp](https://reddit.com/user/Kbknapp)), Keybase ([kbknapp](https://keybase.io/kbknapp)
+* **Contact** Twitter ([@thekbknapp](https://twitter.com/thekbknapp)), reddit ([/u/Kbknapp](https://reddit.com/user/Kbknapp)), Keybase ([kbknapp](https://keybase.io/kbknapp))
 * **Spoken Languages**: _English_, Spanish (intermediate)
 * **Topics**: Beginners, all things CLI, performance, API design, clap, public speaking, systems design
 

--- a/_includes/projects.md
+++ b/_includes/projects.md
@@ -27,10 +27,19 @@ do {
     } while (!/^H[123]$/i.test(e.nodeName));
     people.push(person);
 } while (e.nodeName == 'H3');
-for (let i = people.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [people[i], people[j]] = [people[j], people[i]];
-}
+
+// sort projects by name -- maybe rename array 'people' to 'project'
+people.sort(function(a, b) {
+  return a[0].innerText.localeCompare(b[0].innerText);
+});
+
+/* the below is no longer needed, so I commented it out */
+
+//for (let i = people.length - 1; i > 0; i--) {
+//    const j = Math.floor(Math.random() * (i + 1));
+//    [people[i], people[j]] = [people[j], people[i]];
+//}
+
 people.forEach(person => {
     person.forEach(x => {
         e.parentNode.insertBefore(x, e);


### PR DESCRIPTION
Modified the javascript to:

- sort projects and mentors' names. I feel it's easier to find both projects and mentors that way.

**Small fix**: added the missing the ")" to Kevin Knapp's keybase.
