### PR TITLE
add anchor links for each mentor/project for easy direct linking

### DIFF
--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -156,10 +156,9 @@
 
 ### Jane Lusby ([@yaahc](https://github.com/yaahc))
 * **Pronouns**: she/her
-* **Contact**: Twitter ([@yaahc_](https://twitter.com/yaahc_))
+* **Contact**: Discord (Yaah#0001)
 * **Spoken Languages**: English
-* **Topics**: Beginners, community outreach, cargo, clippy, tracing, CLI, exercism.io, code review
-* **Aditional Resources**: [My work tracker](https://github.com/yaahc/prs/projects/1), I'm especially happy to mentor any of these issues
+* **Topics**: Error Handling, API Design, Beginners, community outreach, cargo, clippy, tracing, CLI, exercism.io, code review
 
 ### Jonathan Turner ([@jonathandturner](https://github.com/jonathandturner))
 * **Pronouns**: any gender pronoun

--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -376,6 +376,14 @@
 * **Additional Resources**:
     - My Blog - [ENOSUCHBLOG](https://blog.yossarian.net)
 
+### Thomas Gideon ([@cmdln](https://github.com/cmdln))
+* **Pronouns**: he/him
+* **Contact**: Twitter ([@cmdln](https://twitter.com/cmdln)), e-mail ([cmdln@thecommandline.net](mailto:cmdln@thecommandline.net?subject=Rust%20Mentorship)), Discord (_cmdln#9288_), Mastodon ([@cmdln@fosstodon.org](https://fosstodon.org/web/accounts/242961))
+* **Spoken Languages**: English
+* **Topics**: CLI, web services, web applications, WASM, DevOps, dev tools
+* **Additional Resources**:
+    - My Blog - [The Command Line](https://thecommandline.net)
+
 <h1 id="mentors-end"></h1>
 
 <script>

--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -368,6 +368,14 @@
 * **Additional Resources**:
    - My Blog - [https://abramov.io/](https://abramov.io/)
 
+### William Woodruff ([@woodruffw](https://github.com/woodruffw))
+* **Pronouns**: he/him
+* **Contact**: Twitter ([@8x5clPW2](https://twitter.com/8x5clPW2)), e-mail ([william@yossarian.net](mailto:william@yossarian.net?subject=Rust%20Mentorship))
+* **Spoken Languages**: English
+* **Topics**: Compilers (LLVM), systems programming, fuzzing, program analysis
+* **Additional Resources**:
+    - My Blog - [ENOSUCHBLOG](https://blog.yossarian.net)
+
 <h1 id="mentors-end"></h1>
 
 <script>

--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -208,17 +208,6 @@
 * **Spoken Languages**: English, Italian
 * **Topics**: Multimedia, cargo, proc-macros, CLI
 
-### Luca Palmieri ([@LukeMathWalker](https://github.com/LukeMathWalker))
-* **Pronouns**: he/him
-* **Contact**: Twitter ([@algo_luca](https://twitter.com/algo_luca)), Email ([rust@lpalmieri.com](mailto:rust@lpalmieri.com))
-* **Spoken Languages**: English, Italian
-* **Topics**: Scientific computing, machine learning, CLI, backend development/enterprise software.
-* **Additional Resources**:
-    * [Taking ML to production with Rust: a 25x speedup](https://www.lpalmieri.com/posts/2019-12-01-taking-ml-to-production-with-rust-a-25x-speedup/)
-    * [Scientific computing: a Rust adventure](https://www.lpalmieri.com/posts/2019-02-23-scientific-computing-a-rust-adventure-part-0-vectors/)
-    * [Writing enterprise software - a Rust experiment](https://docs.google.com/presentation/d/1r5CsiHwqABOTsrN5Dlbf4gCyhcL46NTv7qv9m5mBv-o/edit?usp=sharing)
-    * [A Machine learning introduction to ndarray (workshop)](https://github.com/LukeMathWalker/ndarray-koans)
-
 ### Lucio Franco ([@LucioFranco](https://github.com/LucioFranco))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@lucio_d_franco](https://twitter.com/lucio_d_franco))

--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -2,6 +2,7 @@
 * **Contact** Discord (Aaron1011#7024), Email ([aa1ronham@gmail.com](mailto:aa1ronham@gmail.com))
 * **Spoken Languages**: English
 * **Topics**: Beginners, `rustc` (parser, diagnostics, traits, crate metadata), proc-macros, pin projections, miri
+* **Timezone**: EST (GMT-5)
 * **Additional Resources**: I help maintain [pin-project](https://github.com/taiki-e/pin-project)
 
 ### Ahmed Masud ([@ahmed-masud](https://github.com/ahmed-masud/))
@@ -9,36 +10,42 @@
 * **Contact**: Twitter:([@ahmedmasud](https://twitter.com/ahmedmasud),  Email ([ahmed.masud@saf.ai](mailto:ahmed.masud@saf.ai))
 * **Spoken Languages**: _English_, Hindi, Urdu, some French, translate.google.com in a pinch,
 * **Topics**: Beginners, Basics, CLI, Async, Machine-Learning, AI, File systems, Kernel development, opinions on managing complex projects
+* **Timezone**: EST (GMT-5)
 * **Additional Resources**: I am a relative beginner in Rust, but I have a lot of experience in software engineering and systems design (~30 years) I will share all the ways I've made mistakes :-) so you don't have to repeat any of mine.
 
 ### Amit Upadhyay ([@amitu](https://github.com/amitu))
 * **Pronouns**: Amit Upadhyay
-* **Contact**: Email ([amitu@acko.com](mailto:amitu@acko.com))
+* **Contact**: Email ([amitu@fifthtry.com](mailto:amitu@fifthtry.com))
 * **Spoken Languages**: _English_, Hindi
-* **Topics**: Web Development, CLI, Database, [Realm](http://fifthtry.com/amitu/realm/)
+* **Timezone**: IST (GMT+5.5)
+* **Topics**: Web Development, CLI, Database, [Realm](https://www.amitu.com/realm/), [FTD](https://ftd.dev), [FPM](https://fpm.dev)
 
 ### Ana Hobden ([@hoverbear](https://github.com/hoverbear))
 * **Contact:** Email ([ana@hoverbear.org](mailto:ana@hoverbear.org)), Twitter ([@a_hoverbear](https://twitter.com/a_hoverbear))
 * **Spoken Language:** _English_, some German, some Mandarin
 * **Topics:** Distributed systems, software evolution, infrastructure, architecture, chaos testing, workshops, proc-macros
+* **Timezone**: PST (GMT-8)
 
 ### Andre Bogus ([@llogiq](https://github.com/llogiq))
 * **Pronouns**: he/him
 * **Contact** Twitter ([@llogiq](https://twitter.com/llogiq)), reddit ([/u/llogiq](https://reddit.com/user/llogiq))
 * **Spoken Languages**: _German_, English
 * **Topics**: Procedural macros, writing lints, unsafe code, performance, bit twiddling, public speaking
+* **Timezone**: CET (GMT+1)
 
 ### Andreas Fischer ([@Vengarioth](https://github.com/vengarioth))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@vengarioth](https://twitter.com/vengarioth)), Email ([vengarioth@gmail.com](mailto:vengarioth@gmail.com))
 * **Spoken Languages**: _German_, English
 * **Topics**: Games programming, graphics & rendering, netcode (games), parsers, starting a company in germany
+* **Timezone**: CET (GMT+1)
 
 ### Andrew Yourtchenko ([@ayourtch](https://github.com/ayourtch))
 * **Pronouns**: he/him/them
 * **Contact**: Twitter ([@ayourtch](https://twitter.com/ayourtch))
 * **Spoken Languages**: _English_, Russian
 * **Topics**: Beginners, CLI, iron, mustache, IPv6 & computer networking in general
+* **Timezone**: EST (GMT-5)
 * **Additional Resources**: I would classify myself as an intermediate level in Rust, but I dabble at various levels, e.g. both lower-level like TACACS+ ([takaks](https://github.com/ayourtch/takaks)), FFI ([vpp-rust-plugin](https://github.com/vpp-dev/vpp-rust-plugin)), as well as higher level like web-apps ([rsp10](https://github.com/ayourtch/rsp10)) - will be happy to help and share my experience!
 
 ### Andy Thomason ([@andy-thomason](https://github.com/andy-thomason))
@@ -46,6 +53,7 @@
 * **Contact**: Twitter ([@quaternioso](https://twitter.com/quaternioso))
 * **Spoken Languages**: _English_, French, Spanish
 * **Topics**: Beginners/Intermediate, Iterators, Traits, Procedural macros, Bioinformatics, Performance, LLVM, Autovectorisation, Code transformation, Game development lecturer.
+* **Timezone**: GMT
 * **Additional Resources**:
     * [Oxford Rust Meetup](https://www.meetup.com/Oxford-Rust-Meetup-Group/)
     * [Extendr R bindings](https://github.com/extendr)
@@ -55,30 +63,35 @@
 * **Contact**: Twitter ([@lovesegfault](https://twitter.com/lovesegfault)), Email ([bernardo@meurer.org](mailto://bernardo@meurer.org))
 * **Spoken Languages**: _English_, Portuguese
 * **Topics**: Beginners, intermediates, video, cameras, quantum computers
+* **Timezone**: PST (GMT-8)
 
 ### Bhargav Voleti ([@bIgBV](https://github.com/bIgBV))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@2093bps](https://twitter.com/2093bps))
 * **Spoken Languages**: _English_, Hindi
 * **Topics**: Beginners, async, distributed systems
+* **Timezone**: PST (GMT-8)
 
 ### Cassie Meharry ([@cassiemeharry](https://github.com/cassiemeharry))
 * **Pronouns**: she/her
 * **Contact**: Email ([cassie@prophetessof.tech](mailto://cassie@prophetessof.tech)), Discord (bluejeans#1230)
 * **Spoken Languages**: English
 * **Topics**: Intermediate Rust, `async`/`await`, web, CLI tools, system design
+* **Timezone**: PST (GMT-8)
 
 ### Chuck Pierce ([@charlespierce](https://github.com/charlespierce))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@chuckapierce](https://twitter.com/chuckapierce)), Email ([chuck@charlespierce.dev](mailto://chuck@charlespierce.dev)), Discord (Chuck Pierce#8737)
 * **Spoken Languages**: English
 * **Topics**: Beginner / Intermediate Rust, CLI, Developer Tools, Code Review
+* **Timezone**: PST (GMT-8)
 
 ### Cyryl Płotnicki ([@cyplo](https://github.com/cyplo/))
 * **Pronouns**: he/him/they/them
 * **Contact**: Twitter ([@cyplo](https://twitter.com/cyplo))
 * **Spoken Languages**: English, Polish
 * **Topics**: mentoring others (so meta!), project management, brand-new-to-rust, structuring tests, property-based tests, fuzzers, distributed systems, I/O
+* **Timezone**: GMT
 * **Additional Resources**: I sometimes write about [Rust](https://blog.cyplo.dev/tags/rust/) on my [blog](https://blog.cyplo.dev/)
 
 ### Dimitri Sabadie ([@phaazon](https://github.com/phaazon))
@@ -86,6 +99,7 @@
 * **Contact**: Twitter ([@phaazon](https://twitter.com/phaazon_)), IRC (phaazon on Libera), Email ([dimitri.sabadie@gmail.com](mailto://dimitri.sabadie@gmail.com)), Discord (phaazon#0545)
 * **Spoken Languages**: French, English
 * **Topics**: Graphics programming, procedural macros, unsafe bindings & FFI, functional programming & type theory, parsing, type-driven architectures, low-level optimizations, cargo tools, writing RFCs.
+* **Timezone**: CET (GMT+1)
 * **Additional Resources**:
     * [My blog](https://phaazon.net/blog)
 
@@ -94,60 +108,70 @@
 * **Contact**: Twitter ([@softprops](https://twitter.com/softprops)),  Email ([d.tangren@gmail.com](mailto://d.tangren@gmail.com)), Discord (softprops#1989)
 * **Spoken Languages**: English
 * **Topics**: Beginners, intermediates. Transitioning to Rust from Scala/Java/Typescript. Community. Open source. Effective std lib. Command line tools, AWS/Serverless.
+* **Timezone**: EST (GMT-5)
 
 ### Dylan DPC ([@Dylan-DPC](https://github.com/Dylan-DPC))
 * **Pronouns**: he/him
 * **Contact**: Discord (@dpc), Twitter ([@dpc_22](https://twitter.com/dpc_22))
 * **Spoken Languages**: _English_, German
 * **Topics**: Open to anything that is sort of in the general-purpose domain
+* **Timezone**: CET (GMT+1)
 
 ### Eliza Weisman ([@hawkw](https://github.com/hawkw))
 * **Pronouns**: she/her
 * **Contact**: Email ([eliza@buoyant.io](mailto://eliza@buoyant.io)), Discord (_mycoliza#5146_)
 * **Spoken Languages**: English
 * **Topics**: Async I/O, networking, concurrent data structures. I'm pretty busy and would generally prefer to provide mentoring for contributions to projects I already contribute to ([`tokio`](https://github.com/tokio-rs/tokio), [`tracing`](https://github.com/tokio-rs/tracing),  [`tower`](https://github.com/tower-rs/tower), etc).
+* **Timezone**: PST (GMT-8)
 
 ### Erich Gubler ([@erichdongubler](https://github.com/erichdongubler))
 * **Pronouns**: he/him
 * **Contact**: Email ([erichdongubler@gmail.com](mailto://erichdongubler@gmail.com))
 * **Spoken Languages**: English, Portuguese (BR)
 * **Topics**: Forensics/parsing, workflow (setting up projects, architecture)
+* **Timezone**: EST (GMT-5)
 
 ### Esteban Küber ([@estebank](https://github.com/estebank))
 * **Pronouns**: he/his
 * **Contact**: Twitter ([@ekuber](https://twitter.com/ekuber))
 * **Spoken Languages**: English, Spanish
 * **Topics**: Beginners, `rustc` (parser, diagnostics and in general).
+* **Timezone**: PST (GMT-8)
 
 ### Evan Chan ([@velvia](https://github.com/velvia))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@evanfchan](https://twitter.com/evanfchan)), Instagram([@platypus.arts](https://instagram.com/platypus.arts))
 * **Spoken Languages**: English, some Cantonese/Mandarin
 * **Topics**: Beginner/Intermediate, Transitioning from GC/JVM/Scala/Python, Data Structures, Data Processing, Databases, Compression, High Performance / Benchmarking / SIMD
+* **Timezone**: PST (GMT-8)
 
 ### Gabe Martinez ([@mystal](https://github.com/mystal))
 * **Pronouns**: they/them
 * **Contact**: Twitter ([@mystalice](https://twitter.com/mystalice)), Discord (mystal#3600)
 * **Spoken Languages**: English
 * **Topics**: Beginner/Intermediate Rust, Game Programming (& Design), Rapid Prototyping, Product Management
+* **Timezone**: PST (GMT-8)
 
 ### Giles Cope ([@gilescope](https://github.com/gilescope))
 * **Pronouns**: he/his
 * **Contact**: Twitter ([@gilescope](https://twitter.com/gilescope)) / Reddit (u/gilescope)
 * **Spoken Languages**: English
 * **Topics**: Beginners
+* **Timezone**: GMT
 
 ### Zephyr Shannon ([@RadicalZephyr](https://github.com/RadicalZephyr))
 * **Pronouns**: they/them
 * **Contact**: Discord (_@radicalzephyr#6728_)
 * **Spoken Languages**: English
 * **Topics**: Beginners, intermediates, async/await, macros (by-example and procedural), parsing, tokio
+* **Timezone**: PST (GMT-8)
 
 ### Gray Olson ([@termhn](https://github.com/termhn))
 * **Pronouns**: she/her
 * **Contact**: Twitter ([@fu5ha](https://twitter.com/fu5ha))
 * **Spoken Languages**: English
 * **Topics**: Beginners, graphics, gamedev
+* **Timezone**: MST (GMT-7)
 * **Additional resources**:
     * [learn-gfx-hal](https://rust-tutorials.github.io/learn-gfx-hal/)
     * [learn-rendy](https://github.com/rust-tutorials/learn-rendy/)
@@ -158,25 +182,29 @@
 * **Contact**: Discord (Yaah#0001)
 * **Spoken Languages**: English
 * **Topics**: Error Handling, API Design, Beginners, community outreach, cargo, clippy, tracing, CLI, exercism.io, code review
+* **Timezone**: PST (GMT-8)
 
-### Jonathan Turner ([@jonathandturner](https://github.com/jonathandturner))
-* **Pronouns**: any gender pronoun
+### JT ([@jntrnr](https://github.com/jntrnr))
+* **Pronouns**: they/them
 * **Contact**: Email, Discord (_jturner#3961_), Twitter ([@jntrnr](https://twitter.com/jntrnr))
 * **Spoken Languages**: English
 * **Topics**: Developer experiences, growing projects, Emulation, CLI, and Beginner/Intermediate Rust
+* **Timezone**: between timezones! will update when settled.
 
 ### Jordan Gregory ([@j4ng5y](https://github.com/j4ng5y))
 * **Pronouns**: he/him
 * **Contact**: Discord (_j4ng5y#0157_), Twitter ([@j4ng5y](https://twitter.com/j4ng5y)), Slack (_@Jordan Gregory_)
 * **Spoken Languages**: English
 * **Topics**: Beginner Rust, WASM, CLI, JavaScript Transition / Integration, Go Transition, Python Transition / Integration, Microservices, Kubernetes, Web APIs (RESTful / xRPC)
-* **Additonal Resources**: Meetup ([STLRust](https://www.meetup.com/STL-Rust/)), YouTube ([STLRust](https://youtube.com/channel/UCARDJrGiZxT6_fASoLr3B_g)), Twitch ([j4ng5y](https://www.twitch.tv/j4ng5y))
+* **Timezone**: CST (GMT-6)
+* **Additional Resources**: Meetup ([STLRust](https://www.meetup.com/STL-Rust/)), YouTube ([STLRust](https://youtube.com/channel/UCARDJrGiZxT6_fASoLr3B_g)), Twitch ([j4ng5y](https://www.twitch.tv/j4ng5y))
 
 ### Joshua Mir ([@joshua-mir](https://github.com/joshua-mir))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@jam10o](https://twitter.com/jam10o)), Gitter Parity technical support chat: ([@joshua-mir](https://gitter.im/paritytech/parity))
 * **Spoken Languages**: English
 * **Topics**: Beginner Rust, cryptocurrency, blockchain, parity-ethereum, Substrate runtime development
+* **Timezone**: CET (GMT+1)
 * **Additional Resources**: [Substrate Docs](https://substrate.dev), [Parity (Ethereum) Wiki](https://wiki.parity.io), [Substrate Community Resources](https://substrate.dev/en/community)
 
 ### Kevin Flansburg ([@kflansburg](https://github.com/kflansburg))
@@ -184,6 +212,7 @@
 * **Contact**: email (in GitHub profile), reddit ([/u/chicago_moose](https://www.reddit.com/user/chicago_moose))
 * **Spoken Languages**: English
 * **Topics**: Rust, Microservices, Kubernetes, Kafka, Websockets, Automated Trading
+* **Timezone**: EST (GMT-5)
 * **Additional Resources**: [Krustlet](https://github.com/deislabs/krustlet), [KrustletCRI](https://github.com/kflansburg/krustlet-cri)
 
 ### Kevin Knapp ([@kbknapp](https://github.com/kbknapp))
@@ -191,39 +220,46 @@
 * **Contact** Twitter ([@thekbknapp](https://twitter.com/thekbknapp)), reddit ([/u/Kbknapp](https://reddit.com/user/Kbknapp)), Keybase ([kbknapp](https://keybase.io/kbknapp)
 * **Spoken Languages**: _English_, Spanish (intermediate)
 * **Topics**: Beginners, all things CLI, performance, API design, clap, public speaking, systems design
+* **Timezone**: EST (GMT-5)
 
 ### lcnr ([@lcnr](https://github.com/lcnr))
 * **Pronouns**: they/them
 * **Contact**: Zulip ([@lcnr](https://rust-lang.zulipchat.com/)), Twitter ([@lcnr7](https://twitter.com/lcnr7))
 * **Spoken Languages**: _English_, German
 * **Topics**: Beginners, intermediates, traits, unsafe code, compilers (both **rustc** and [others](https://github.com/lcnr/computer))
+* **Timezone**: CET (GMT+1)
 
 ### Lokathor ([@lokathor](https://github.com/lokathor))
 * **Contact**: Twitter ([@Lokathor](https://twitter.com/Lokathor)), Discord (_Lokathor#2627_)
 * **Spoken Languages**: English
 * **Topics**: Beginners, intermediates, unsafe, FFI, SIMD
+* **Timezone**: MST (GMT-7)
 
 ### Luca Barbato ([@lu-zero](https://github.com/lu-zero))
 * **Contact**: IRC (lu_zero on [freenode.net](http://webchat.freenode.net/?channels=%23rust-av&uio=d4)), Telegram ([lu_zero](https://telegram.me/lu_zero))
 * **Spoken Languages**: English, Italian
 * **Topics**: Multimedia, cargo, proc-macros, CLI
+* **Timezone**: CET (GMT+1)
 
 ### Lucio Franco ([@LucioFranco](https://github.com/LucioFranco))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@lucio_d_franco](https://twitter.com/lucio_d_franco))
 * **Spoken Languages**: _English_, Italian, French
 * **Topics**: Async io, networking, distributed systems, game dev, compilers
+* **Timezone**: EST (GMT-5)
 
 ### Maher Khalil ([@maherkhalil07](https://github.com/maherkhalil07))
 * **Contact**:maherkhalil@outlook.com
 * **Spoken Languages**: English, Arabic
 * **Topics**: Beginners
+* **Timezone**: AST (GMT+3)
 
 ### Marco Ieni ([@MarcoIeni](https://github.com/MarcoIeni))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@MarcoIeni](https://twitter.com/MarcoIeni)), LinkedIn ([@MarcoIeni](https://www.linkedin.com/in/MarcoIeni/)), Discord (MarcoIeni#7180)
 * **Spoken Languages**: English, Italian
 * **Topics**: Embedded, CLI, testing, beginners, basics (lifetimes, ownership, error handling..), developer tools, Continuous integration
+* **Timezone**: CET (GMT+1)
 * **Additional Resources**:
     * [Rust GitHub Template](https://rust-github.github.io/)
 
@@ -232,6 +268,7 @@
 * **Contact**: Twitter ([@daogangtang](https://twitter.com/daogangtang))
 * **Spoken Languages**: Mandarin, English
 * **Topics**: Beginners, community meetup, wasm, web framework, orm, substrate...
+* **Timezone**: China Standard Time (GMT+8)
 * **Additional Resources**:
   - [rust.cc](https://rust.cc)
   - [rustforce.net](https://rustforce.net)
@@ -241,6 +278,7 @@
 * **Contact**: Twitter ([@NikolaiVazquez](https://twitter.com/NikolaiVazquez)), Email ([nikvzqz@gmail.com](mailto:nikvzqz@gmail.com)), Discord ([nvzqz#4477](https://discordapp.com/invite/rust-lang))
 * **Spoken Languages**: _English_, Spanish, German
 * **Topics**: Learning Rust from nothing or experienced newcomers
+* **Timezone**: EST (GMT-5)
 * **Additional Resources**: I maintain [Static Assertions](https://github.com/nvzqz/static-assertions-rs), so I'd be happy to teach people how it works
 
 ### Phil Krones ([@flip1995](https://github.com/flip1995))
@@ -248,42 +286,56 @@
 * **Contact**: GitHub ([@flip1995](https://github.com/flip1995)), E-Mail ([hello@philkrones.com](mailto:hello@philkrones.com)), Discord ([flip1995#2683](https://discordapp.com/users/618807455651987476); not that active there)
 * **Spoken Languages**: German, English
 * **Topics**: Beginners, Clippy, Lints, Diagnostics
+* **Timezone**: CET (GMT+1)
 
 ### Raj ([@avranju](https://github.com/avranju/))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@avranju](https://twitter.com/avranju))
 * **Spoken Languages**: English
 * **Topics**: Networking, async I/O, beginner/intermediate Rust
+* **Timezone**: IST (GMT+5.5)
 
 ### Robert Winslow ([@rw](https://github.com/rw))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@robert_winslow](https://twitter.com/robert_winslow))
 * **Spoken Languages**: English
 * **Topics**: Distributed systems, low-latency, testing, formal methods, Bayesian statistics, machine learning, deep learning, serialization. async/await, [FlatBuffers](https://github.com/google/flatbuffers), testing, minimizing heap allocations, lifetimes, traits, borrow-checker, API design
+* **Timezone**: PST (GMT-8)
 * **Additional Resources**: Video of a [talk I presented at Mozilla HQ on FlatBuffers in Rust](https://www.youtube.com/watch?v=YsiQDX20lXI).
 
 ### Roman Proskuryakov ([@kpp](https://github.com/kpp))
 * **Contact**: Github ([@kpp](https://github.com/kpp)), Email ([r.proskuryakoff@gmail.com](mailto:r.proskuryakoff@gmail.com)), Telegram ([gitkpp](https://t.me/gitkpp)),
 * **Spoken Languages**: English, Russian
 * **Topics**: Beginner/Intermediate Rust, async, futures, CI
+* **Timezone**: MSK (GMT+3)
 
 ### Shady Khalifa ([@shekohex](https://github.com/shekohex))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@shekohex](https://twitter.com/ShekoHex))
 * **Spoken Languages**: _Arabic_, English
 * **Topics**: Networking, FFI, CLI, parsers, development tools, web (server-side)
+* **Timezone**: EET (GMT+2)
 
 ### Søren Mortensen ([@nerosnm](https://github.com/nerosnm))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@nerosnm](https://twitter.com/nerosnm)), Email ([soren@neros.dev](mailto:soren@neros.dev))
 * **Spoken Languages**: English
 * **Topics**: Beginners/the basics, developer tools, CLI, Rust–Swift/Objective-C interop
+* **Timezone**: CET (GMT+1)
+
+### Thomas Adam ([@ThomasAdam](https://github.com/ThomasAdam))
+* **Pronouns**: he/him
+* **Contact**: Email ([thomas@xteddy.org](mailto:thomas@xteddy.org)), IRC ([thomas_adam](https://libera.chat/))
+* **Spoken Languages**: English
+* **Topics**: Beginner, CLI/TUI tools, FFI (C), Parsers, X11/Window management
+* **Timezone**: GMT
 
 ### Tim McNamara ([@timClicks](https://github.com/timClicks))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@timClicks](https://twitter.com/timClicks)), Discord ([timClicks#4198](https://discord.gg/rust-lang)), Reddit ([u/timClicks](https://www.reddit.com/user/timClicks))
 * **Spoken Languages**: _English_, German
 * **Topics**: Rust for people who know Python/Ruby/JavaScript, data science, natural language processing
+* **Timezone**: NZDT (GMT+13)
 * **Additional Resources**:
    * Twitch stream: https://twitch.tv/timclicks
    * YouTube channel: https://youtube.com/c/timClicks
@@ -293,6 +345,7 @@
 * **Contact**: Twitter ([@Erstejahre](https://twitter.com/Erstejahre)), Email ([william@blackhats.net.au](mailto:william@blackhats.net.au))
 * **Spoken Languages**: English
 * **Topics**: Code review, beginners, C-FFI, concurrency, data structures, security, identity management aka authentication
+* **Timezone**: AEST (GMT+10)
 * **Additional Resources**:
     * [Programming lessons and methods](https://fy.blackhats.net.au/blog/html/2019/02/26/programming_lessons_and_methods.html)
     * [LDAP guide](https://fy.blackhats.net.au/blog/html/pages/ldap_guide_part_1_foundations.html)
@@ -304,17 +357,20 @@
 * **Contact**: Discord ([uint128_t#5905](https://discordapp.com/invite/rust-lang))
 * **Spoken Languages**: English, French
 * **Topics**: Actix, Kubernetes, Docker builds
+* **Timezone**: PST (GMT-8)
 
 ### Zack M. Davis ([@zackmdavis](https://github.com/zackmdavis))
 * **Contact**: Twitter ([@zackmdavis](https://twitter.com/zackmdavis)), email ([code@zackmdavis.net](mailto:code@zackmdavis.net)), Discord (_zackmdavis#3944_)
 * **Spoken Languages**: English
 * **Topics**: Language basics, rustc development (especially diagnostics)
+* **Timezone**: PST (GMT-8)
 
 ### Andrew Lilley Brinker ([@alilleybrinker](https://github.com/alilleybrinker))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@alilleybrinker](https://twitter.com/alilleybrinker))
 * **Spoken Languages**: English
 * **Topics**: Software security, software assurance, software supply chain security.
+* **Timezone**: PST (GMT-8)
 * **Additional Resources**:
     * [Possible Rust](https://www.possiblerust.com/)
 
@@ -333,12 +389,14 @@
 * **Contact**: Twitter ([@\_berwyn\_](https://twitter.com/_berwyn_)), Discord (berwyn#0956)
 * **Spoken Languages**: English
 * **Topics**: Beginners, code review, coding practices, Docker, cargo, clippy
+* **Timezone**: EST (GMT-5)
 
 ### T.J. Telan ([@tjtelan](https://github.com/tjtelan))
 * **Pronouns**: he/him/they/them
 * **Contact**: Twitter([@ThatTJTelan](https://twitter.com/ThatTJTelan))
 * **Spoken Languages**: English
 * **Topics**: CLI, DevOps (CI/CD, automation, tools, infrastructure), distributed systems, embedded systems, wasm, beginner/intermediate Rust
+* **Timezone**: PST (GMT-8)
 * **Additional Resources**:
    - My Blog - https://tjtelan.com/ (Or just the [Rust stuff](https://tjtelan.com/tags/rust/))
    - My Twitch channel - https://www.twitch.tv/tjtelan
@@ -348,6 +406,7 @@
 * **Contact**: Twitter([@aarondjents](https://twitter.com/aarondjents))
 * **Spoken Languages**: English
 * **Topics**: infra, graph algorithms, graph databases, software testing, testing frameworks, scaling, dev tooling, devx
+* **Timezone**: CST (GMT-6)
 * **Additional Resources**:
    - My Blog - [https://abramov.io/](https://abramov.io/)
 
@@ -356,6 +415,7 @@
 * **Contact**: Twitter ([@8x5clPW2](https://twitter.com/8x5clPW2)), e-mail ([william@yossarian.net](mailto:william@yossarian.net?subject=Rust%20Mentorship))
 * **Spoken Languages**: English
 * **Topics**: Compilers (LLVM), systems programming, fuzzing, program analysis
+* **Timezone**: EST (GMT-5)
 * **Additional Resources**:
     - My Blog - [ENOSUCHBLOG](https://blog.yossarian.net)
 
@@ -364,6 +424,7 @@
 * **Contact**: Twitter ([@cmdln](https://twitter.com/cmdln)), e-mail ([cmdln@thecommandline.net](mailto:cmdln@thecommandline.net?subject=Rust%20Mentorship)), Discord (_cmdln#9288_), Mastodon ([@cmdln@fosstodon.org](https://fosstodon.org/web/accounts/242961))
 * **Spoken Languages**: English
 * **Topics**: CLI, web services, web applications, WASM, DevOps, dev tools
+* **Timezone**: EST (GMT-5)
 * **Additional Resources**:
     - My Blog - [The Command Line](https://thecommandline.net)
 
@@ -392,4 +453,43 @@ people.forEach(person => {
     });
 });
 e.remove();
+
+Array
+  .from(document.querySelectorAll("h3"))
+  .filter(el => !['Expectations For Mentees', 'Missing Mentor Topics', 'Exercism.io', 'Expectations For Mentors']
+        .includes(el.innerText)
+  )
+  .forEach(el => addAnchorLink(el))
+
+
+const addAnchorLink = el => {
+    const anchor = document.createElement('a')
+    anchor.href = `#${el.id}`
+    const svg = createSVGForAnchorLink()
+    anchor.appendChild(svg)
+
+    const anchorSpan = document.createElement('span')
+    anchorSpan.appendChild(anchor)
+    el.appendChild(anchorSpan)
+}
+
+const createSVGForAnchorLink = () => {
+    // use anchor link SVG icon from https://heroicons.com/
+    let svg = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+    svg.setAttribute("class", "h-5 w-5")
+    svg.setAttribute("viewBox", "0 0 20 20")
+    svg.setAttribute("fill", "currentColor")
+
+    let path = document.createElementNS("http://www.w3.org/2000/svg", "path")
+    path.setAttribute("fill-rule", "evenodd")
+    path.setAttribute("d", "M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z")
+    path.setAttribute("clip-rule", "evenodd")
+    svg.appendChild(path)
+
+    svg.style.height = ".8em"
+    svg.style.marginLeft = ".5em"
+
+    return svg
+}
+
 </script>

--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -267,13 +267,6 @@
 * **Spoken Languages**: English
 * **Topics**: Networking, async I/O, beginner/intermediate Rust
 
-### Ravi ([@wafflespeanut](https://github.com/wafflespeanut))
-* **Pronouns**: he/him
-* **Contact**: Twitter ([@wafflespeanut](https://twitter.com/wafflespeanut))
-* **Spoken Languages**: _Tamil_, English
-* **Topics**: Beginners, CLI, web, coding practices, clean + maintainable code.
-* **Additional Resources**: I'm actively working on [paperclip](https://github.com/wafflespeanut/paperclip), a WIP OpenAPI tooling library. I'd love to give a hand if anyone's interested!
-
 ### Robert Winslow ([@rw](https://github.com/rw))
 * **Pronouns**: he/him
 * **Contact**: Twitter ([@robert_winslow](https://twitter.com/robert_winslow))

--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -323,9 +323,12 @@
 * **Topics**: Language basics, rustc development (especially diagnostics)
 
 ### Andrew Lilley Brinker ([@alilleybrinker](https://github.com/alilleybrinker))
+* **Pronouns**: he/him
 * **Contact**: Twitter ([@alilleybrinker](https://twitter.com/alilleybrinker))
 * **Spoken Languages**: English
-* **Topics**: Language (beginner through advanced [I teach Rust]), FFI, Software Assurance, Type System
+* **Topics**: Software security, software assurance, software supply chain security.
+* **Additional Resources**:
+    * [Possible Rust](https://www.possiblerust.com/)
 
 ### Tyler Neely ([@spacejam](https://github.com/spacejam))
 * **Contact**: Discord ([@spacejam#5759 on the Rust discord](https://discord.gg/rust-lang))

--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -52,10 +52,9 @@
 
 ### Bernardo Meurer ([@lovesegfault](https://github.com/lovesegfault/))
 * **Preferred Pronouns**: he/him
-* **Contact**: Twitter ([@lovesegfault](https://twitter.com/lovesegfault)), Email ([bernardo@standard.ai](mailto://bernardo@standard.ai))
+* **Contact**: Twitter ([@lovesegfault](https://twitter.com/lovesegfault)), Email ([bernardo@meurer.org](mailto://bernardo@meurer.org))
 * **Spoken Languages**: _English_, Portuguese
-* **Topics**: Beginners, intermediates, video, cameras, data transports, distributed systems
-* **Additional Resources**: You can see the [slides of the talk I gave](https://lovesegfault.com/files/rustlab-2019.pdf) this year as a reference on the kind of stuff I work with.
+* **Topics**: Beginners, intermediates, video, cameras, quantum computers
 
 ### Bhargav Voleti ([@bIgBV](https://github.com/bIgBV))
 * **Pronouns**: he/him

--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -84,9 +84,9 @@
 
 ### Dimitri Sabadie ([@phaazon](https://github.com/phaazon))
 * **Pronouns**: he/him
-* **Contact**: Twitter ([@phaazon](https://twitter.com/phaazon_)), IRC (phaazon on Freenode), Email ([dimitri.sabadie@gmail.com](mailto://dimitri.sabadie@gmail.com)), Discord (phaazon#0545)
+* **Contact**: Twitter ([@phaazon](https://twitter.com/phaazon_)), IRC (phaazon on Libera), Email ([dimitri.sabadie@gmail.com](mailto://dimitri.sabadie@gmail.com)), Discord (phaazon#0545)
 * **Spoken Languages**: French, English
-* **Topics**: Graphics programming, procedural macros, unsafe bindings & FFI, functional programming & type theory, parsing, type-driven architectures, blockchains, low-level optimizations, cargo tools, writing RFCs.
+* **Topics**: Graphics programming, procedural macros, unsafe bindings & FFI, functional programming & type theory, parsing, type-driven architectures, low-level optimizations, cargo tools, writing RFCs.
 * **Additional Resources**:
     * [My blog](https://phaazon.net/blog)
 

--- a/_includes/projects.md
+++ b/_includes/projects.md
@@ -4,6 +4,7 @@
 * **Spoken Languages**: English, _Canadian English_
 * **Recommended Experience**: Beginner - Intermediate
 * **Topics**: 2D Computer Graphics, Game Engine, Interprocess-Communication, Async, WebAssembly
+* **Timezone**: PST (GMT-8)
 
 ### [Dotenv-linter](https://dotenv-linter.github.io) - ⚡️ Lightning-fast linter for `.env` files. Written in Rust 🦀
 * **Repo**: https://github.com/dotenv-linter/dotenv-linter
@@ -11,6 +12,7 @@
 * **Spoken Languages**: English
 * **Recommended Experience**: Beginner
 * **Topics**: CLI, Linters, Dotenv
+* **Timezone**: MSK (GMT+3)
 
 ### [OpenPowerlifting](https://www.openpowerlifting.org/) - Database, compiler, webserver, and data for the sport of Powerlifting. It's all Rust!
 * **Repo**: [https://gitlab.com/openpowerlifting/opl-data](https://gitlab.com/openpowerlifting/opl-data)
@@ -18,6 +20,7 @@
 * **Spoken Languages**: English, Esperanto
 * **Recommended Experience**: Beginner - Intermediate
 * **Topics**: Webservers, Compilers, Databases, Data Analysis
+* **Timezone**: MST (GMT-7)
 
 ### [cargo-tarpaulin](https://github.com/xd009642/tarpaulin) - Code coverage for rust, source analysis, tracing, reporting
 * **Repo** [https://github.com/xd009642/tarpaulin](https://github.com/xd009642/tarpaulin)
@@ -25,6 +28,7 @@
 * **Spoken Languages**: English
 * **Recommended Experience**: All
 * **Topics**: Code coverage, CLI tools, Interprocess Communication, Binary analysis
+* **Timezone**: GMT
 
 ### [Linfa](https://github.com/rust-ml/linfa/) - A Rust machine learning framework
 * **Repo**: [https://github.com/rust-ml/linfa](https://github.com/rust-ml/linfa)


### PR DESCRIPTION
Fixes #151.

This is a bit brittle because 

- it relies on `el.innerText` to decide which `h3`s to _not_ add an anchor link to
- it presumes that all `h3`s without a given `innerText` are eligible for an anchor link

But it works for the current site, at least.