### PR TITLE
add anchor links for each mentor/project for easy direct linking

### DIFF
--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -453,4 +453,43 @@ people.forEach(person => {
     });
 });
 e.remove();
+
+Array
+  .from(document.querySelectorAll("h3"))
+  .filter(el => !['Expectations For Mentees', 'Missing Mentor Topics', 'Exercism.io', 'Expectations For Mentors']
+        .includes(el.innerText)
+  )
+  .forEach(el => addAnchorLink(el))
+
+
+const addAnchorLink = el => {
+    const anchor = document.createElement('a')
+    anchor.href = `#${el.id}`
+    const svg = createSVGForAnchorLink()
+    anchor.appendChild(svg)
+
+    const anchorSpan = document.createElement('span')
+    anchorSpan.appendChild(anchor)
+    el.appendChild(anchorSpan)
+}
+
+const createSVGForAnchorLink = () => {
+    // use anchor link SVG icon from https://heroicons.com/
+    let svg = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+    svg.setAttribute("class", "h-5 w-5")
+    svg.setAttribute("viewBox", "0 0 20 20")
+    svg.setAttribute("fill", "currentColor")
+
+    let path = document.createElementNS("http://www.w3.org/2000/svg", "path")
+    path.setAttribute("fill-rule", "evenodd")
+    path.setAttribute("d", "M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z")
+    path.setAttribute("clip-rule", "evenodd")
+    svg.appendChild(path)
+
+    svg.style.height = ".8em"
+    svg.style.marginLeft = ".5em"
+
+    return svg
+}
+
 </script>


### PR DESCRIPTION
This could be improved if we manually add IDs to the headings which shouldn't have anchor links, but this works at least for the current site.

Things that could break this JS-based anchor link generation:

1) changing from `h3`s to some other HTML tag for each mentor's heading.
2) changing the text of the `h3`s which aren't mentor headings.