### PR TITLE
remove lcnr from mentors

### DIFF
--- a/_includes/mentors.md
+++ b/_includes/mentors.md
@@ -223,13 +223,6 @@
 * **Topics**: Beginners, all things CLI, performance, API design, clap, public speaking, systems design
 * **Timezone**: EST (GMT-5)
 
-### lcnr ([@lcnr](https://github.com/lcnr))
-* **Pronouns**: they/them
-* **Contact**: Zulip ([@lcnr](https://rust-lang.zulipchat.com/)), Twitter ([@lcnr7](https://twitter.com/lcnr7))
-* **Spoken Languages**: _English_, German
-* **Topics**: Beginners, intermediates, traits, unsafe code, compilers (both **rustc** and [others](https://github.com/lcnr/computer))
-* **Timezone**: CET (GMT+1)
-
 ### Lokathor ([@lokathor](https://github.com/lokathor))
 * **Contact**: Twitter ([@Lokathor](https://twitter.com/Lokathor)), Discord (_Lokathor#2627_)
 * **Spoken Languages**: English


### PR DESCRIPTION
Don't really have the capacity to mentor people outside of `E-mentor` rustc issues and don't expect that to change over the next few months. After recently telling multiple people that I cannot provide much help, I think it's better to just completely remove myself from this list.